### PR TITLE
Update CNPJ check digits exception message terminology

### DIFF
--- a/packages/cnpj-dv/CHANGELOG.md
+++ b/packages/cnpj-dv/CHANGELOG.md
@@ -1,5 +1,11 @@
 # lacus/cnpj-dv
 
+## 1.2.0
+
+### Improvements
+
+- **Error messages**: `CnpjCheckDigitsInputLengthException` refers to "characters" instead of "digits" to match alphanumeric input support.
+
 ## 1.1.0
 
 ### New Features

--- a/packages/cnpj-dv/src/Exceptions/CnpjCheckDigitsInputLengthException.php
+++ b/packages/cnpj-dv/src/Exceptions/CnpjCheckDigitsInputLengthException.php
@@ -33,7 +33,7 @@ class CnpjCheckDigitsInputLengthException extends CnpjCheckDigitsException
             ? (string) strlen($evaluatedInput)
             : strlen($evaluatedInput) . ' in "' . $evaluatedInput . '"';
 
-        parent::__construct("CNPJ input {$fmtActual} does not contain {$minExpectedLength} to {$maxExpectedLength} digits. Got {$fmtEvaluated}.");
+        parent::__construct("CNPJ input {$fmtActual} does not contain {$minExpectedLength} to {$maxExpectedLength} characters. Got {$fmtEvaluated}.");
         $this->actualInput = $actualInput;
         $this->evaluatedInput = $evaluatedInput;
         $this->minExpectedLength = $minExpectedLength;

--- a/packages/cnpj-dv/tests/specs/Exceptions.spec.php
+++ b/packages/cnpj-dv/tests/specs/Exceptions.spec.php
@@ -191,7 +191,7 @@ describe('CnpjCheckDigitsInputLengthException', function () {
             $evaluatedInput = '12345';
             $minExpectedLength = 12;
             $maxExpectedLength = 14;
-            $actualMessage = 'CNPJ input "'.$actualInput.'" does not contain '.$minExpectedLength.' to '.$maxExpectedLength.' digits. Got '.strlen($evaluatedInput).' in "'.$evaluatedInput.'".';
+            $actualMessage = 'CNPJ input "'.$actualInput.'" does not contain '.$minExpectedLength.' to '.$maxExpectedLength.' characters. Got '.strlen($evaluatedInput).' in "'.$evaluatedInput.'".';
 
             $exception = new CnpjCheckDigitsInputLengthException(
                 $actualInput,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined an input-length error message to use clearer, more consistent wording.
  * Updated related validation messaging so length mismatches are described in terms of characters rather than digits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->